### PR TITLE
Fix CSS errors

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,16 +1,24 @@
 <!doctype html>
+
 <html lang="en">
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
+    <!-- Download Rubik font if not present on client's computer. -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
-    <meta charset="UTF-8" />
+    
+    <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/Stonks_emoji.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
     <title>Fantasy Reddit</title>    
-    <script type="module" src="./staticRestyleCode/public/js/btn--toggle-sidebar.js"></script>
-
+    
+    <!-- Sidebar functionality -->
+    <script type="module" src="./public/js/btn--toggle-sidebar.js"></script>
   </head>
+  
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/client/public/css/base/base.css
+++ b/client/public/css/base/base.css
@@ -13,13 +13,13 @@ body {
   grid: "header header" auto "sidebar main" 1fr/max-content 1fr;
   overflow: hidden;
 }
-body > header {
+body #page-header {
   grid-area: header;
 }
-body > aside {
+body #sidebar {
   grid-area: sidebar;
 }
-body > main {
+body #main {
   grid-area: main;
 }
 @media screen and (max-width: 48rem) {
@@ -562,7 +562,7 @@ Sidebar
 @media screen and (max-width: 48rem) {
   #sidebar {
     position: absolute;
-    z-index: 10;
+    z-index: 1;
     top: 15.5rem;
     width: 100%;
   }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,12 +40,3 @@
 .read-the-docs {
   color: #888;
 }
-
-@import url("https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap");
-body {
-  font-family: 'Rubik', sans-serif;
-}
-
-#root {
-    display: contents;
-}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,9 @@ import Transactions from './components/Transactions';
 import Portfolio from './components/Portfolio';
 import Options from './components/Options';
 
+import './ReactOverrides.css';
 import '../staticRestyleCode/public/css/base/base.css';
+
 import { useContext, useEffect, useState, type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, NavLink, Outlet, Navigate, useNavigate } from 'react-router-dom';
 
@@ -51,7 +53,7 @@ function Navigation() {
                                 <use href="./assets/svg/magnification-list-icon.svg#magnification-list-icon"></use>
                             </svg>
 
-                            {/* <input id="search-field" type="text" placeholder="Search for threads" name="search-query"> */}
+                            <input id="search-field" type="text" placeholder="Search for threads" name="search-query"/>
                         </div>
                     </form>
                 </li>
@@ -354,7 +356,7 @@ function App() {
     <BrowserRouter>
       <Navigation />
       <Sidebar />
-      <main>
+      <main id="main">
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/login" element={<Login />} />

--- a/client/src/ReactOverrides.css
+++ b/client/src/ReactOverrides.css
@@ -1,0 +1,4 @@
+#root {
+    /* Pretend like this box doesn't exist when other boxes relate to it. */
+    display: contents;
+}

--- a/client/staticRestyleCode/public/css/base/base.css
+++ b/client/staticRestyleCode/public/css/base/base.css
@@ -13,13 +13,13 @@ body {
   grid: "header header" auto "sidebar main" 1fr/max-content 1fr;
   overflow: hidden;
 }
-body > header {
+body #page-header {
   grid-area: header;
 }
-body > aside {
+body #sidebar {
   grid-area: sidebar;
 }
-body > main {
+body #main {
   grid-area: main;
 }
 @media screen and (max-width: 48rem) {
@@ -562,7 +562,7 @@ Sidebar
 @media screen and (max-width: 48rem) {
   #sidebar {
     position: absolute;
-    z-index: 10;
+    z-index: 1;
     top: 15.5rem;
     width: 100%;
   }

--- a/client/staticRestyleCode/src/scss/base/_base_resets.scss
+++ b/client/staticRestyleCode/src/scss/base/_base_resets.scss
@@ -35,13 +35,13 @@ body {
     // ... to scroll past the body and its contents. I'm not sure why..
     overflow: hidden;
         
-    > header {
+    #page-header {
         grid-area: header;
     }
-    > aside {
+    #sidebar {
         grid-area: sidebar;
     }
-    > main {
+    #main {
         grid-area: main;
     }
     


### PR DESCRIPTION
- Ensure body children are lain out correctly when they are wrapped with a #root div.

- Remove unused lines of CSS (App.css wasn't used anyway since it's for the old style,
but had some stuff for the new style added to it).